### PR TITLE
ls: extension file color

### DIFF
--- a/src/ls.c
+++ b/src/ls.c
@@ -4761,13 +4761,29 @@ get_color_indicator (const struct fileinfo *f, bool symlink_target)
     {
       /* Test if NAME has a recognized suffix.  */
 
+
+//ZONE DE MODIFICATIONS : 
+//On utilise le ls dans l'archive coreutils directement (on aurait pu utiliser un aliase)
+//make au niveau de coreutils, puis cd /src, ./ls, ./ls --color
+
+
+
       len = strlen (name);
       name += len;		/* Pointer to final \0.  */
       for (ext = color_ext_list; ext != NULL; ext = ext->next)
         {
+            char *tmp; //Cette variable temporaire représente le lowercase du char UNIQUEMENT pendant la comparaison sans modifier la valeur originale "name"
+            tmp = malloc(sizeof(char) * strlen(name - ext->ext.len) + 1); //allocation mémoire de la taille de name - la taille de l'extension 
+            strcpy(tmp, name - ext->ext.len);//on mets la chaîne originale à comparer dans tmp 
+            for (int i = 0; i <= strlen(tmp); i++)
+            {
+                if (tmp[i] >= 65 && tmp[i] <= 90)//Lowercase de la chaîne originale (ASCII)
+                    tmp[i] = tmp[i] + 32;
+            }
+
           if (ext->ext.len <= len
-              && STREQ_LEN (name - ext->ext.len, ext->ext.string,
-                            ext->ext.len))
+              && STREQ_LEN (tmp, ext->ext.string,
+                            ext->ext.len))//On remplace la chaine originale par le tmp en minuscule parce que la liste chainée d'extension connait .jpg en minuscule
             break;
         }
     }


### PR DESCRIPTION
Hi,

We have tried to make an improvement to the terminal for the ls command
The system recognizes a file with its extension in lowercase, for example:
→ chat.jpg is recognized as a .jpg file so on the terminal, it will be shown in purple
→ chat (copy).JPG will not be recognized as a .jpg file so, on the terminal, it will be shown in the default color (in our case, it is white)
The purpose of this enhancement is to display in color, files with the same extension in lowercase or uppercase (following the base color code)

After looking in the file where the functions need to be changed, we found in line 4678 a function that compared the extension types with the color code in dircolors.

 ```
static const struct bin_str * _GL_ATTRIBUTE_PURE
get_color_indicator (const struct fileinfo * f, bool symlink_target)
```

We declare a char * tmp variable that will be used to convert a capital letter to lowercase BUT without changing it, it will be recognized as a lowercase variable without becoming a lowercase (we do not want to change the value of "name").

Then, we make a memory allocation of the size of name subtracted to the size of the extension.
We use the strcpy function to put the original string that we want to compare in the tmp.
Then, we add a condition in the for loop,

```
if (tmp [i]> = 65 && tmp [i] <= 90) // Lowercase of the original string (ASCII).
                     tmp [i] = tmp [i] + 32;
             }
```
(Search between A and Z:
65 → A
90 → Z)

It is here that we indicate that we will interpret the extension in upper case, then "convert" it into lowercase (→ tmp [i] = tmp [i] + 32).

Then, we replace the original string by the tmp in lowercase because the linked list of extension recognizes a file having the extension .jpg but in lowercase.


```
 if (type == C_FILE) {
len = strlen (name);
      name += len;		/* Pointer to final \0.  */
      for (ext = color_ext_list; ext != NULL; ext = ext->next)
        {
            char *tmp;
            tmp = malloc(sizeof(char) * strlen(name - ext->ext.len) + 1); 
            strcpy(tmp, name - ext->ext.len);
            for (int i = 0; i <= strlen(tmp); i++)
            {
                if (tmp[i] >= 65 && tmp[i] <= 90)
                    tmp[i] = tmp[i] + 32;
            }

          if (ext->ext.len <= len
              && STREQ_LEN (tmp, ext->ext.string,
                            ext->ext.len))
            break;
        }
    }
```